### PR TITLE
Syntax highlight cson as coffeescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is an Emacs extension for Atom.
 
 You can install it from `Atom -> Preferences -> Settings -> Packages`. To enable emacs-mode automatically on Atom starts, put following code to your init script:
 
-```
+```coffeescript
 atom.packages.enablePackage('emacs-mode').activateNow()
 ```
 
@@ -23,7 +23,7 @@ atom.packages.enablePackage('emacs-mode').activateNow()
 
 ## Keymap
 
-```
+```coffeescript
 '.editor':
   'ctrl-a': 'editor:move-to-first-character-of-line'
   'ctrl-e': 'editor:move-to-end-of-line'
@@ -85,7 +85,7 @@ atom.packages.enablePackage('emacs-mode').activateNow()
 ## Configuration
 Below are the default configurations:
 
-```
+```coffeescript
 'emacs-mode':
   'hideTabs': false              # hide tabs
   'hideSidebar': false           # hide tree view


### PR DESCRIPTION
Makes it a little more inviting to read.

Won't show up on packages page yet, but Github will highlight it in the readme.
Guessing that at some point, packages page will get syntax highlighting, too,
and then it will show up there, as well.
